### PR TITLE
[BN-1571]: Disable maven release until new repo can be created

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,10 @@ jobs:
       java-versions: >-
         ["11"]
       preserve-cache-between-runs: true
-  maven-release:
-    uses: ./.github/workflows/maven_release.yml
-    needs: sbt-build
-    secrets: inherit
+  # maven-release:
+  #   uses: ./.github/workflows/maven_release.yml
+  #   needs: sbt-build
+  #   secrets: inherit
   deploy-docs:
     uses: ./.github/workflows/deploy_docs.yml
     needs: sbt-build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,8 +18,8 @@ jobs:
   #   uses: ./.github/workflows/maven_release.yml
   #   needs: sbt-build
   #   secrets: inherit
-  deploy-docs:
-    uses: ./.github/workflows/deploy_docs.yml
-    needs: sbt-build
-    # Only update Github Pages if this is a release tag
-    if: startsWith(github.ref, 'refs/tags/v')
+  # deploy-docs:
+  #   uses: ./.github/workflows/deploy_docs.yml
+  #   needs: sbt-build
+  #   # Only update Github Pages if this is a release tag
+  #   if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Purpose
Disable the Maven release step so the CI/CD can be green and allow others to contribute.

## Approach
* Comment out `maven-release` step in GitHub actions.
* Comment out `deploy-docs` step.

## Testing
PR passed.

## Tickets
* BN-1571
