### PR TITLE
TSDK-714 Added Asset Merging Validation

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
@@ -59,10 +59,12 @@ object TransactionSyntaxError {
    * A Syntax error indicating that this transaction contains invalid UpdateProposals
    */
   case class InvalidUpdateProposal(outputs: Seq[Value.UpdateProposal]) extends TransactionSyntaxError
+
   /**
    * A Syntax error indicating that this transaction contains invalid MergingStatements
    */
   case class InvalidMergingStatements(statements: Seq[AssetMergingStatement]) extends TransactionSyntaxError
+
   /**
    * A Syntax error indicating that the request merging operation is invalid
    */

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
@@ -59,9 +59,12 @@ object TransactionSyntaxError {
    * A Syntax error indicating that this transaction contains invalid UpdateProposals
    */
   case class InvalidUpdateProposal(outputs: Seq[Value.UpdateProposal]) extends TransactionSyntaxError
-
   /**
    * A Syntax error indicating that this transaction contains invalid MergingStatements
    */
   case class InvalidMergingStatements(statements: Seq[AssetMergingStatement]) extends TransactionSyntaxError
+  /**
+   * A Syntax error indicating that the request merging operation is invalid
+   */
+  case class IncompatibleMerge(inputs: Seq[Value.Asset], output: Value.Asset) extends TransactionSyntaxError
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
@@ -1,7 +1,7 @@
 package co.topl.brambl.validation
 
 import co.topl.brambl.models.TransactionOutputAddress
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.{AssetMergingStatement, Value}
 import co.topl.brambl.models.transaction.Schedule
 import quivr.models.{Proof, Proposition}
 
@@ -59,4 +59,9 @@ object TransactionSyntaxError {
    * A Syntax error indicating that this transaction contains invalid UpdateProposals
    */
   case class InvalidUpdateProposal(outputs: Seq[Value.UpdateProposal]) extends TransactionSyntaxError
+
+  /**
+   * A Syntax error indicating that this transaction contains invalid MergingStatements
+   */
+  case class InvalidMergingStatements(statements: Seq[AssetMergingStatement]) extends TransactionSyntaxError
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
@@ -61,12 +61,17 @@ object TransactionSyntaxError {
   case class InvalidUpdateProposal(outputs: Seq[Value.UpdateProposal]) extends TransactionSyntaxError
 
   /**
-   * A Syntax error indicating that this transaction contains invalid MergingStatements
+   * A Syntax error indicating that this transaction contains an invalid MergingStatement
    */
-  case class InvalidMergingStatements(statements: Seq[AssetMergingStatement]) extends TransactionSyntaxError
+  case class InvalidMergingStatement(statement: AssetMergingStatement) extends TransactionSyntaxError
+
+  /**
+   * A Syntax error indicating that a merging input in a transaction is non-distinct
+   */
+  case class NonDistinctMergingInput(input: TransactionOutputAddress) extends TransactionSyntaxError
 
   /**
    * A Syntax error indicating that the request merging operation is invalid
    */
-  case class IncompatibleMerge(inputs: Seq[Value.Asset], output: Value.Asset) extends TransactionSyntaxError
+  case class IncompatibleMerge(inputs: Seq[Value], output: Value) extends TransactionSyntaxError
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -634,7 +634,7 @@ object TransactionSyntaxInterpreter {
     type AsmCheck = AssetMergingStatement => Boolean
     val outputIdxInBounds: AsmCheck = _.outputIdx < transaction.outputs.size
     val multipleInputs: AsmCheck = _.inputUtxos.length >= 2
-    val allInputsPresent: AsmCheck = _.inputUtxos.forall { input => transaction.inputs.exists(_.address == input) }
+    val allInputsPresent: AsmCheck = _.inputUtxos.forall(input => transaction.inputs.exists(_.address == input))
     val distinctInputs: AsmCheck = s => s.inputUtxos.distinct.length == s.inputUtxos.length
 
     def isValidStatement: AsmCheck = s =>
@@ -680,7 +680,14 @@ object TransactionSyntaxInterpreter {
     }
 
     def isValidMerge: MergeCheck = v =>
-      Seq(allAssetInputs, assetOutput, sumInputsEqualsOutput, sameQuantityDescriptors, sameFungibility, validFungibility).forall(_(v))
+      Seq(
+        allAssetInputs,
+        assetOutput,
+        sumInputsEqualsOutput,
+        sameQuantityDescriptors,
+        sameFungibility,
+        validFungibility
+      ).forall(_(v))
 
     val toMerge = transaction.mergingStatements.map(asm =>
       MergingValues(

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -9,7 +9,6 @@ import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.models.{GroupId, LockAddress, LockId, SeriesId}
-import co.topl.brambl.syntax._
 import co.topl.genus.services.Txo
 import com.google.protobuf.ByteString
 import quivr.models.Int128
@@ -29,35 +28,49 @@ import quivr.models.Int128
  */
 class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with MockHelpers {
 
-  val validator = TransactionSyntaxInterpreter.make[Id]()
+  private val validator = TransactionSyntaxInterpreter.make[Id]()
 
   private val mockTransaction = IoTransaction.defaultInstance.withDatum(txDatum)
 
   // The following mock lock address and attestation are used for all the UTXOs in the tests
   private val mockLock = Lock.Predicate(List(MockHeightProposition).map(Challenge().withRevealed), 1)
-  private val mockLockAddress =  LockAddress(0, 0, LockId(Lock().withPredicate(mockLock).sizedEvidence.digest.value))
+  private val mockLockAddress = LockAddress(0, 0, LockId(Lock().withPredicate(mockLock).sizedEvidence.digest.value))
   private val mockAttestation = Attestation().withPredicate(Attestation.Predicate(mockLock, List(MockHeightProof)))
 
-  private val mockAsset = Value.Asset(quantity = Int128(ByteString.copyFrom(BigInt(1).toByteArray)), fungibility = FungibilityType.GROUP)
+  private val mockAsset =
+    Value.Asset(quantity = Int128(ByteString.copyFrom(BigInt(1).toByteArray)), fungibility = FungibilityType.GROUP)
 
   private val dummyBytes = ByteString.copyFrom(Array.fill(32)(0.toByte))
 
-  private val groupTxos = for (i <- 1 to 3) yield Txo(
-    transactionOutput = UnspentTransactionOutput(mockLockAddress, Value.defaultInstance.withAsset(
-    mockAsset
-      .withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
-      .withGroupId(GroupId(dummyBytes))
-  )), outputAddress = dummyTxoAddress.withIndex(i)
-  )
+  private val groupTxos =
+    for (i <- 1 to 3)
+      yield Txo(
+        transactionOutput = UnspentTransactionOutput(
+          mockLockAddress,
+          Value.defaultInstance.withAsset(
+            mockAsset
+              .withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
+              .withGroupId(GroupId(dummyBytes))
+          )
+        ),
+        outputAddress = dummyTxoAddress.withIndex(i)
+      )
   private val mergedGroup = MergingOps.merge(groupTxos, mockLockAddress, None, None)
 
-  private val seriesTxos = for (i <- 4 to 6) yield Txo(
-    transactionOutput = UnspentTransactionOutput(mockLockAddress, Value.defaultInstance.withAsset(
-    mockAsset.withFungibility(FungibilityType.SERIES)
-      .withSeriesId(SeriesId(dummyBytes))
-      .withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
-  )), outputAddress = dummyTxoAddress.withIndex(i)
-  )
+  private val seriesTxos =
+    for (i <- 4 to 6)
+      yield Txo(
+        transactionOutput = UnspentTransactionOutput(
+          mockLockAddress,
+          Value.defaultInstance.withAsset(
+            mockAsset
+              .withFungibility(FungibilityType.SERIES)
+              .withSeriesId(SeriesId(dummyBytes))
+              .withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
+          )
+        ),
+        outputAddress = dummyTxoAddress.withIndex(i)
+      )
   private val mergedSeries = MergingOps.merge(seriesTxos, mockLockAddress, None, None)
 
   /**
@@ -68,7 +81,12 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
   test("Valid complex case") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 1)
     val asmSeries = AssetMergingStatement(seriesTxos.map(_.outputAddress), 2)
-    val inputs = (for (txo <- groupTxos ++ seriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)) :+ SpentTransactionOutput(dummyTxoAddress, mockAttestation, lvlValue)
+    val inputs = (for (txo <- groupTxos ++ seriesTxos)
+      yield SpentTransactionOutput(
+        txo.outputAddress,
+        mockAttestation,
+        txo.transactionOutput.value
+      )) :+ SpentTransactionOutput(dummyTxoAddress, mockAttestation, lvlValue)
     val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue), mergedGroup, mergedSeries)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmSeries))
 
@@ -76,27 +94,35 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
 
     assert(result.isDefined) // If the result is defined, the validation passed
   }
+
   /**
    * input UTXOs are not reused in multiple merging statements
    */
   test("Invalid case, an input UTXO is present in multiple merging statements") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
     val asmGroupDup = AssetMergingStatement(groupTxos.map(_.outputAddress), 1)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroup, mergedGroup)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmGroupDup))
+    val testTx =
+      mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmGroupDup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup, asmGroupDup))))
+    val assertError =
+      result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup, asmGroupDup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * input UTXOs are not reused in multiple merging statements
    */
   test("Invalid case, an input UTXO is present multiple times in the same merging statement") {
     val asmGroup = AssetMergingStatement((groupTxos :+ groupTxos.head).map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(MergingOps.merge(groupTxos :+ groupTxos.head, mockLockAddress, None, None))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
@@ -105,12 +131,14 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * merging statement contain 2 or more asset inputs that exist in the transaction
    */
   test("Invalid case, merging statement only contains 1 input") {
     val asmGroup = AssetMergingStatement(Seq(groupTxos.head.outputAddress), 0)
-    val inputs = Seq(SpentTransactionOutput(groupTxos.head.outputAddress, mockAttestation, groupTxos.head.transactionOutput.value))
+    val inputs =
+      Seq(SpentTransactionOutput(groupTxos.head.outputAddress, mockAttestation, groupTxos.head.transactionOutput.value))
     val outputs = Seq(MergingOps.merge(Seq(groupTxos.head), mockLockAddress, None, None))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
@@ -119,12 +147,15 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * merging statement contain 2 or more asset inputs that exist in the transaction
    */
   test("Invalid case, merging statement contains a txo that does not exist in the transaction inputs") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos.tail) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupTxos.tail)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(MergingOps.merge(groupTxos.tail, mockLockAddress, None, None))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
@@ -133,12 +164,15 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * merging statement's output's index does not refer to an asset output
    */
   test("Invalid case, merging statement's output index is out of bounds") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 1)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroup)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
@@ -147,12 +181,15 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * input UTXOs are not present in the transaction outputs
    */
   test("Invalid case, an input UTXO to merge is also present in the transaction outputs") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroup, UnspentTransactionOutput(mockLockAddress, groupTxos.head.transactionOutput.value))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
@@ -161,6 +198,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * merging statement contain 2 or more asset inputs that exist in the transaction
    */
@@ -175,12 +213,15 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * merging statement's output's index does not refer to an asset output
    */
   test("Invalid case, merging statement's output index refers to a non-asset") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
@@ -189,28 +230,43 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
    */
   test("Invalid case, UTXOs share GROUP_AND_SERIES fungibility type") {
-    val groupSeriesTxos = for (i <- 1 to 3) yield Txo(
-      transactionOutput = UnspentTransactionOutput(mockLockAddress, Value.defaultInstance.withAsset(
-        mockAsset.withFungibility(FungibilityType.GROUP_AND_SERIES)
-          .withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
-          .withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
-      )), outputAddress = dummyTxoAddress.withIndex(i)
-    )
+    val groupSeriesTxos =
+      for (i <- 1 to 3)
+        yield Txo(
+          transactionOutput = UnspentTransactionOutput(
+            mockLockAddress,
+            Value.defaultInstance.withAsset(
+              mockAsset
+                .withFungibility(FungibilityType.GROUP_AND_SERIES)
+                .withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
+                .withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
+            )
+          ),
+          outputAddress = dummyTxoAddress.withIndex(i)
+        )
     val mergedGroupSeries = MergingOps.merge(groupSeriesTxos, mockLockAddress, None, None)
     val asmGroupSeries = AssetMergingStatement(groupSeriesTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupSeriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- groupSeriesTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroupSeries)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroupSeries))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
    */
@@ -218,200 +274,365 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val mockTxos = groupTxos :+ seriesTxos.head
     val mockOutput = MergingOps.merge(mockTxos, mockLockAddress, None, None)
     val asm = AssetMergingStatement(mockTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- mockTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- mockTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
    */
   test("Invalid case, the output does not share the same fungibility type as the inputs") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.withFungibility(FungibilityType.SERIES))))
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedGroup.copy(value =
+        mergedGroup.value.withAsset(mergedGroup.value.getAsset.withFungibility(FungibilityType.SERIES))
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * all UTXOs (inputs and the new output) share the same quantity descriptor type
    */
   test("Invalid case, all inputs do not share the same quantity descriptor type") {
-    val mockTxos = groupTxos.tail :+ groupTxos.head.copy(transactionOutput = groupTxos.head.transactionOutput.copy(value = groupTxos.head.transactionOutput.value.withAsset(groupTxos.head.transactionOutput.value.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR))))
+    val mockTxos = groupTxos.tail :+ groupTxos.head.copy(transactionOutput =
+      groupTxos.head.transactionOutput.copy(value =
+        groupTxos.head.transactionOutput.value.withAsset(
+          groupTxos.head.transactionOutput.value.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR)
+        )
+      )
+    )
     val mockOutput = MergingOps.merge(mockTxos, mockLockAddress, None, None)
     val asm = AssetMergingStatement(mockTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- mockTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- mockTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * all UTXOs (inputs and the new output) share the same quantity descriptor type
    */
   test("Invalid case, the output does not share the same quantity descriptor type as the inputs") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR))))
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedGroup.copy(value =
+        mergedGroup.value.withAsset(
+          mergedGroup.value.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR)
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If group fungible, all UTXOs must share the same group ID.
    */
   test("Invalid case, all inputs do not share the same group id") {
-    val mockTxos = groupTxos.tail :+ groupTxos.head.copy(transactionOutput = groupTxos.head.transactionOutput.copy(value = groupTxos.head.transactionOutput.value.withAsset(groupTxos.head.transactionOutput.value.getAsset.withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(99.toByte)))))))
+    val mockTxos = groupTxos.tail :+ groupTxos.head.copy(transactionOutput =
+      groupTxos.head.transactionOutput.copy(value =
+        groupTxos.head.transactionOutput.value.withAsset(
+          groupTxos.head.transactionOutput.value.getAsset
+            .withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(99.toByte))))
+        )
+      )
+    )
     val mockOutput = MergingOps.merge(mockTxos, mockLockAddress, None, None)
     val asm = AssetMergingStatement(mockTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- mockTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- mockTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If group fungible, all UTXOs must share the same group ID.
    */
   test("Invalid case, the output does not share the group id as the inputs") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(99.toByte)))))))
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedGroup.copy(value =
+        mergedGroup.value.withAsset(
+          mergedGroup.value.getAsset.withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(99.toByte))))
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If group fungible, The new output must have a valid seriesAlloy/seriesId.
    */
   test("Invalid case, the output does not have a series alloy") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.clearSeriesAlloy)))
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs =
+      Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.clearSeriesAlloy)))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If group fungible, The new output must have a valid seriesAlloy/seriesId.
    */
   test("Invalid case, the output has a seriesId defined") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(99.toByte)))))))
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedGroup.copy(value =
+        mergedGroup.value.withAsset(
+          mergedGroup.value.getAsset.withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(99.toByte))))
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If group fungible, The new output must have a valid seriesAlloy.
    */
   test("Invalid case, the output's series alloy is not a valid merkle root of the inputs") {
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.withSeriesAlloy(mergedSeries.value.getAsset.getGroupAlloy))))
+    val inputs =
+      for (txo <- groupTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedGroup.copy(value =
+        mergedGroup.value.withAsset(
+          mergedGroup.value.getAsset.withSeriesAlloy(mergedSeries.value.getAsset.getGroupAlloy)
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If series fungible, all UTXOs must share the same series ID.
    */
   test("Invalid case, all inputs do not share the same series id") {
-    val mockTxos = seriesTxos.tail :+ seriesTxos.head.copy(transactionOutput = seriesTxos.head.transactionOutput.copy(value = seriesTxos.head.transactionOutput.value.withAsset(seriesTxos.head.transactionOutput.value.getAsset.withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(99.toByte)))))))
+    val mockTxos = seriesTxos.tail :+ seriesTxos.head.copy(transactionOutput =
+      seriesTxos.head.transactionOutput.copy(value =
+        seriesTxos.head.transactionOutput.value.withAsset(
+          seriesTxos.head.transactionOutput.value.getAsset
+            .withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(99.toByte))))
+        )
+      )
+    )
     val mockOutput = MergingOps.merge(mockTxos, mockLockAddress, None, None)
     val asm = AssetMergingStatement(mockTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- mockTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val inputs =
+      for (txo <- mockTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If series fungible, all UTXOs must share the same series ID.
    */
   test("Invalid case, the output does not share the series id as the inputs") {
     val asmGroup = AssetMergingStatement(seriesTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- seriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedSeries.copy(value = mergedSeries.value.withAsset(mergedSeries.value.getAsset.withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(99.toByte)))))))
+    val inputs =
+      for (txo <- seriesTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedSeries.copy(value =
+        mergedSeries.value.withAsset(
+          mergedSeries.value.getAsset.withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(99.toByte))))
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If series fungible, The new output must have a valid groupAlloy/groupId .
    */
   test("Invalid case, the output does not have a group alloy") {
     val asmGroup = AssetMergingStatement(seriesTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- seriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedSeries.copy(value = mergedSeries.value.withAsset(mergedSeries.value.getAsset.clearGroupAlloy)))
+    val inputs =
+      for (txo <- seriesTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs =
+      Seq(mergedSeries.copy(value = mergedSeries.value.withAsset(mergedSeries.value.getAsset.clearGroupAlloy)))
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If series fungible, The new output must have a valid groupAlloy/groupId .
    */
   test("Invalid case, the output has a group id defined") {
     val asmGroup = AssetMergingStatement(seriesTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- seriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedSeries.copy(value = mergedSeries.value.withAsset(mergedSeries.value.getAsset.withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(99.toByte)))))))
+    val inputs =
+      for (txo <- seriesTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedSeries.copy(value =
+        mergedSeries.value.withAsset(
+          mergedSeries.value.getAsset.withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(99.toByte))))
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
+
   /**
    * If series fungible, The new output must have a valid groupAlloy.
    */
   test("Invalid case, the output's group alloy is not a valid merkle root of the inputs") {
     val asmGroup = AssetMergingStatement(seriesTxos.map(_.outputAddress), 0)
-    val inputs = for (txo <- seriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedSeries.copy(value = mergedSeries.value.withAsset(mergedSeries.value.getAsset.withGroupAlloy(mergedGroup.value.getAsset.getSeriesAlloy))))
+    val inputs =
+      for (txo <- seriesTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedSeries.copy(value =
+        mergedSeries.value.withAsset(
+          mergedSeries.value.getAsset.withGroupAlloy(mergedGroup.value.getAsset.getSeriesAlloy)
+        )
+      )
+    )
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
-    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)))
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -1,0 +1,123 @@
+package co.topl.brambl.validation
+
+import cats.implicits._
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.common.ContainsEvidence.Ops
+import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
+import co.topl.brambl.models.box.{Attestation, Challenge, Lock}
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.models.{LockAddress, LockId}
+import co.topl.brambl.syntax._
+
+/**
+ * Test to coverage Asset Merging:
+ * - all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
+ * - all UTXOs (inputs and the new output) share the same quantity descriptor type
+ * - all UTXOs (inputs and the new output) have valid series/group alloy and IDs:
+ *    - If group fungible, all UTXOs must share the same group ID. The new output must have a valid seriesAlloy and no seriedId
+ *    - If series fungible, all UTXOs must share the same series ID. The new output must have a valid groupAlloy and no groupId
+ * - the alloy fields are a valid merkle root of the input UTXO's values (in lexicographic order)
+ * - input UTXOs are not reused in multiple merging statements
+ * - input UTXOs are not present in the transaction outputs
+ */
+class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with MockHelpers {
+
+  private val mockTransaction = IoTransaction.defaultInstance.withDatum(txDatum)
+
+  // The following mock lock address and attestation are used for all the UTXOs in the tests
+  private val mockLock = Lock.Predicate(List(MockHeightProposition).map(Challenge().withRevealed), 1)
+  private val mockLockAddress =  LockAddress(0, 0, LockId(Lock().withPredicate(mockLock).sizedEvidence.digest.value))
+  private val mockAttestation = Attestation().withPredicate(Attestation.Predicate(mockLock, List(MockHeightProof)))
+
+  // use dummyTxoAddress for txoAddress (just update the index)
+
+//  case class PartitionedMerge(inputs: Seq[Value], output: Value, asm: MergingStatement)
+
+//  private def partitionMergingState
+
+  /**
+   * input UTXOs are not reused in multiple merging statements
+   */
+  test("Invalid case, an input UTXO is present in multiple merging statements") {
+  }
+  /**
+   * input UTXOs are not present in the transaction outputs
+   */
+  test("Invalid case, an input UTXO to merge is also present in the transaction outputs") {
+  }
+  /**
+   * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
+   */
+  test("Invalid case, UTXOs share GROUP_AND_SERIES fungibility type") {
+  }
+  /**
+   * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
+   */
+  test("Invalid case, all inputs do not share the same fungibility type") {
+  }
+  /**
+   * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
+   */
+  test("Invalid case, the output does not share the same fungibility type as the inputs") {
+  }
+  /**
+   * all UTXOs (inputs and the new output) share the same quantity descriptor type
+   */
+  test("Invalid case, all inputs do not share the same fungibility type") {
+  }
+  /**
+   * all UTXOs (inputs and the new output) share the same quantity descriptor type
+   */
+  test("Invalid case, the output does not share the same quantity descriptor type as the inputs") {
+  }
+  /**
+   * If group fungible, all UTXOs must share the same group ID.
+   */
+  test("Invalid case, all inputs do not share the same group id") {
+  }
+  /**
+   * If group fungible, all UTXOs must share the same group ID.
+   */
+  test("Invalid case, the output does not share the group id as the inputs") {
+  }
+  /**
+   * If group fungible, The new output must have a valid seriesAlloy/seriesId.
+   */
+  test("Invalid case, the output does not have a series alloy") {
+  }
+  /**
+   * If group fungible, The new output must have a valid seriesAlloy/seriesId.
+   */
+  test("Invalid case, the output has a seriesId defined") {
+  }
+  /**
+   * If group fungible, The new output must have a valid seriesAlloy.
+   */
+  test("Invalid case, the output's series alloy is not a valid merkle root of the inputs") {
+  }
+  /**
+   * If series fungible, all UTXOs must share the same series ID.
+   */
+  test("Invalid case, all inputs do not share the same series id") {
+  }
+  /**
+   * If series fungible, all UTXOs must share the same series ID.
+   */
+  test("Invalid case, the output does not share the series id as the inputs") {
+  }
+  /**
+   * If series fungible, The new output must have a valid groupAlloy/groupId .
+   */
+  test("Invalid case, the output does not have a group alloy") {
+  }
+  /**
+   * If series fungible, The new output must have a valid groupAlloy/groupId .
+   */
+  test("Invalid case, the output has a group id defined") {
+  }
+  /**
+   * If series fungible, The new output must have a valid groupAlloy.
+   */
+  test("Invalid case, the output's group alloy is not a valid merkle root of the inputs") {
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -1,13 +1,18 @@
 package co.topl.brambl.validation
 
+import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
+import co.topl.brambl.builders.MergingOps
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
-import co.topl.brambl.models.box.{Attestation, Challenge, Lock}
-import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.models.{LockAddress, LockId}
+import co.topl.brambl.models.box._
+import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.models.{GroupId, LockAddress, LockId, SeriesId}
 import co.topl.brambl.syntax._
+import co.topl.genus.services.Txo
+import com.google.protobuf.ByteString
+import quivr.models.Int128
 
 /**
  * Test to coverage Asset Merging:
@@ -17,10 +22,14 @@ import co.topl.brambl.syntax._
  *    - If group fungible, all UTXOs must share the same group ID. The new output must have a valid seriesAlloy and no seriedId
  *    - If series fungible, all UTXOs must share the same series ID. The new output must have a valid groupAlloy and no groupId
  * - the alloy fields are a valid merkle root of the input UTXO's values (in lexicographic order)
+ * - merging statement contain 2 or more asset inputs that exist in the transaction
+ * - merging statement's output's index does not refer to an asset output
  * - input UTXOs are not reused in multiple merging statements
  * - input UTXOs are not present in the transaction outputs
  */
 class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with MockHelpers {
+
+  val validator = TransactionSyntaxInterpreter.make[Id]()
 
   private val mockTransaction = IoTransaction.defaultInstance.withDatum(txDatum)
 
@@ -29,21 +38,156 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
   private val mockLockAddress =  LockAddress(0, 0, LockId(Lock().withPredicate(mockLock).sizedEvidence.digest.value))
   private val mockAttestation = Attestation().withPredicate(Attestation.Predicate(mockLock, List(MockHeightProof)))
 
-  // use dummyTxoAddress for txoAddress (just update the index)
+  private val mockAsset = Value.Asset(quantity = Int128(ByteString.copyFrom(BigInt(1).toByteArray)), fungibility = FungibilityType.GROUP)
 
-//  case class PartitionedMerge(inputs: Seq[Value], output: Value, asm: MergingStatement)
+  private val dummyBytes = ByteString.copyFrom(Array.fill(32)(0.toByte))
 
-//  private def partitionMergingState
+  private val groupTxos = for (i <- 1 to 3) yield Txo(
+    transactionOutput = UnspentTransactionOutput(mockLockAddress, Value.defaultInstance.withAsset(
+    mockAsset
+      .withSeriesId(SeriesId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
+      .withGroupId(GroupId(dummyBytes))
+  )), outputAddress = dummyTxoAddress.withIndex(i)
+  )
+  private val mergedGroup = MergingOps.merge(groupTxos, mockLockAddress, None, None)
 
+  private val seriesTxos = for (i <- 4 to 6) yield Txo(
+    transactionOutput = UnspentTransactionOutput(mockLockAddress, Value.defaultInstance.withAsset(
+    mockAsset.withFungibility(FungibilityType.SERIES)
+      .withSeriesId(SeriesId(dummyBytes))
+      .withGroupId(GroupId(ByteString.copyFrom(Array.fill(32)(i.toByte))))
+  )), outputAddress = dummyTxoAddress.withIndex(i)
+  )
+  private val mergedSeries = MergingOps.merge(seriesTxos, mockLockAddress, None, None)
+
+  /**
+   * Valid complex case:
+   * - 2 asset merging statements, one for group fungible and one for series fungible (3 assets each)
+   * - Transaction contains other UTXOs that are not used in the merging statements
+   */
+  test("Valid complex case") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 1)
+    val asmSeries = AssetMergingStatement(seriesTxos.map(_.outputAddress), 2)
+    val inputs = (for (txo <- groupTxos ++ seriesTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)) :+ SpentTransactionOutput(dummyTxoAddress, mockAttestation, lvlValue)
+    val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue), mergedGroup, mergedSeries)
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmSeries))
+
+    val result = validator.validate(testTx).toOption
+
+    assert(result.isDefined) // If the result is defined, the validation passed
+  }
   /**
    * input UTXOs are not reused in multiple merging statements
    */
   test("Invalid case, an input UTXO is present in multiple merging statements") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
+    val asmGroupDup = AssetMergingStatement(groupTxos.map(_.outputAddress), 1)
+    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(mergedGroup, mergedGroup)
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmGroupDup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup, asmGroupDup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+  /**
+   * input UTXOs are not reused in multiple merging statements
+   */
+  test("Invalid case, an input UTXO is present multiple times in the same merging statement") {
+    val asmGroup = AssetMergingStatement((groupTxos :+ groupTxos.head).map(_.outputAddress), 0)
+    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(MergingOps.merge(groupTxos :+ groupTxos.head, mockLockAddress, None, None))
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+  /**
+   * merging statement contain 2 or more asset inputs that exist in the transaction
+   */
+  test("Invalid case, merging statement only contains 1 input") {
+    val asmGroup = AssetMergingStatement(Seq(groupTxos.head.outputAddress), 0)
+    val inputs = Seq(SpentTransactionOutput(groupTxos.head.outputAddress, mockAttestation, groupTxos.head.transactionOutput.value))
+    val outputs = Seq(MergingOps.merge(Seq(groupTxos.head), mockLockAddress, None, None))
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+  /**
+   * merging statement contain 2 or more asset inputs that exist in the transaction
+   */
+  test("Invalid case, merging statement contains a txo that does not exist in the transaction inputs") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
+    val inputs = for (txo <- groupTxos.tail) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(MergingOps.merge(groupTxos.tail, mockLockAddress, None, None))
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+  /**
+   * merging statement's output's index does not refer to an asset output
+   */
+  test("Invalid case, merging statement's output index is out of bounds") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 1)
+    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(mergedGroup)
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
   /**
    * input UTXOs are not present in the transaction outputs
    */
   test("Invalid case, an input UTXO to merge is also present in the transaction outputs") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
+    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(mergedGroup, UnspentTransactionOutput(mockLockAddress, groupTxos.head.transactionOutput.value))
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+  /**
+   * merging statement contain 2 or more asset inputs that exist in the transaction
+   */
+  test("Invalid case, merging statement's inputs are not assets") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
+    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, lvlValue)
+    val outputs = for (_ <- groupTxos.indices) yield UnspentTransactionOutput(mockLockAddress, lvlValue)
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+  /**
+   * merging statement's output's index does not refer to an asset output
+   */
+  test("Invalid case, merging statement's output index refers to a non-asset") {
+    val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
+    val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue))
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
   /**
    * all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -114,7 +114,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val expectedErrors = groupTxos.map(txo => TransactionSyntaxError.NonDistinctMergingInput(txo.outputAddress))
     val assertError = result.exists(_.forall(expectedErrors.contains))
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    assertEquals(result.map(_.toList.size).getOrElse(0), expectedErrors.length)
   }
 
   /**
@@ -178,7 +178,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val inputs =
       for (txo <- groupTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
-    val outputs = Seq(mergedGroup)
+    val outputs = Seq()
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
@@ -248,7 +248,10 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       _.toList.contains(TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value), outputs.head.value))
     )
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    assertEquals(
+      result.map(_.toList.size).getOrElse(0),
+      2
+    ) // 2 errors, one for the input incompatible merge, the other for insufficient funds (lvl has no input)
   }
 
   /**

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -15,16 +15,17 @@ import quivr.models.Int128
 
 /**
  * Test to coverage Asset Merging:
- * - all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
- * - all UTXOs (inputs and the new output) share the same quantity descriptor type
- * - all UTXOs (inputs and the new output) have valid series/group alloy and IDs:
- *    - If group fungible, all UTXOs must share the same group ID. The new output must have a valid seriesAlloy and no seriedId
- *    - If series fungible, all UTXOs must share the same series ID. The new output must have a valid groupAlloy and no groupId
- * - the alloy fields are a valid merkle root of the input UTXO's values (in lexicographic order)
- * - merging statement contain 2 or more asset inputs that exist in the transaction
- * - merging statement's output's index does not refer to an asset output
- * - input UTXOs are not reused in multiple merging statements
- * - input UTXOs are not present in the transaction outputs
+ *    - all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
+ *    - all UTXOs (inputs and the new output) share the same quantity descriptor type
+ *    - all UTXOs (inputs and the new output) have valid series/group alloy and IDs:
+ *       - If group fungible, all UTXOs must share the same group ID. The new output must have a valid seriesAlloy and no seriedId
+ *       - If series fungible, all UTXOs must share the same series ID. The new output must have a valid groupAlloy and no groupId
+ *    - the alloy fields are a valid merkle root of the input UTXO's values (in lexicographic order)
+ *    - merging statement contain 2 or more asset inputs that exist in the transaction
+ *    - merging statement's output's index does not refer to an asset output
+ *    - input UTXOs are not reused in multiple merging statements
+ *    - input UTXOs are not present in the transaction outputs
+ *    - quantity in the merged output is the sum of the inputs
  */
 class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with MockHelpers {
 
@@ -90,9 +91,9 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue), mergedGroup, mergedSeries)
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmSeries))
 
-    val result = validator.validate(testTx).toOption
-
-    assert(result.isDefined) // If the result is defined, the validation passed
+    val result = validator.validate(testTx)
+    println(result)
+    assert(result.toOption.isDefined) // If the result is defined, the validation passed
   }
 
   /**
@@ -109,6 +110,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmGroupDup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError =
       result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup, asmGroupDup))))
     assertEquals(assertError, true)
@@ -127,6 +129,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -143,6 +146,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -160,6 +164,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -177,6 +182,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -194,6 +200,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -209,6 +216,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -226,6 +234,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(_.toList.contains(TransactionSyntaxError.InvalidMergingStatements(Seq(asmGroup))))
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
@@ -258,6 +267,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroupSeries))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -281,6 +291,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -306,6 +317,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -335,6 +347,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -362,6 +375,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -392,6 +406,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -419,6 +434,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -441,6 +457,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -468,6 +485,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -495,6 +513,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -525,6 +544,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -552,6 +572,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -574,6 +595,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -601,6 +623,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
@@ -628,6 +651,35 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
     val result = validator.validate(testTx).swap
+    println(result)
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)
+      )
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * quantity in the merged output is the sum of the inputs
+   */
+  test("Invalid case, the output's quantity is not the sum of the inputs") {
+    val asmGroup = AssetMergingStatement(seriesTxos.map(_.outputAddress), 0)
+    val inputs =
+      for (txo <- seriesTxos)
+        yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
+    val outputs = Seq(
+      mergedSeries.copy(value =
+        mergedSeries.value.withAsset(
+          mergedSeries.value.getAsset.withQuantity(Int128(ByteString.copyFrom(BigInt(1).toByteArray)))
+        )
+      )
+    )
+    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val result = validator.validate(testTx).swap
+    println(result)
     val assertError = result.exists(
       _.toList.contains(
         TransactionSyntaxError.IncompatibleMerge(inputs.map(_.value.getAsset), outputs.head.value.getAsset)


### PR DESCRIPTION
## Purpose

To add asset merging validation

## Approach

Added new Transaction syntax validation rules to ensure valid asset merging. Most rules are taken from TIP-003, however, some additional rules were added as well: 

```
*    - all UTXOs (inputs and the new output) share the same (non group-and-series) fungibility type
 *    - all UTXOs (inputs and the new output) share the same quantity descriptor type
 *    - all UTXOs (inputs and the new output) have valid series/group alloy and IDs:
 *       - If group fungible, all UTXOs must share the same group ID. The new output must have a valid seriesAlloy and no seriedId
 *       - If series fungible, all UTXOs must share the same series ID. The new output must have a valid groupAlloy and no groupId
 *    - the alloy fields are a valid merkle root of the input UTXO's values (in lexicographic order)
 *    - merging statement contain 2 or more asset inputs that exist in the transaction
 *    - merging statement's output's index does not refer to an asset output
 *    - input UTXOs are not reused in multiple merging statements
 *    - input UTXOs are not present in the transaction outputs
 *    - quantity in the merged output is the sum of the inputs
```

## Testing

Added a new test suite and ensured existing tests pass

## Tickets
* Closes TSDK-714
