### PR TITLE
TSDK-763 Network ID Mismatched Validation

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
@@ -74,4 +74,9 @@ object TransactionSyntaxError {
    * A Syntax error indicating that the request merging operation is invalid
    */
   case class IncompatibleMerge(inputs: Seq[Value], output: Value) extends TransactionSyntaxError
+
+  /**
+   * A Syntax error indicating that the lock addresses in the transaction do not all share the same network ID
+   */
+  case class InconsistentNetworkIDs(networkIDs: Set[Int]) extends TransactionSyntaxError
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -47,7 +47,8 @@ object TransactionSyntaxInterpreter {
       mintingValidation,
       updateProposalValidation,
       mergingDistinctValidation,
-      mergingValidation
+      mergingValidation,
+      lockAddressesNetworkIdValidation
     )
 
   /**
@@ -703,4 +704,16 @@ object TransactionSyntaxInterpreter {
     }
   }
 
+  /**
+   * Validate that all the lock addresses in the transaction share the same network ID
+   */
+  private def lockAddressesNetworkIdValidation(transaction: IoTransaction): ValidatedNec[TransactionSyntaxError, Unit] = {
+    val networkIds = transaction.inputs.map(_.address.network) ++ transaction.outputs.map(_.address.network)
+    val distinctNetworkIds = networkIds.distinct
+    Validated.condNec(
+      distinctNetworkIds.length == 1,
+      (),
+      TransactionSyntaxError.InconsistentNetworkIDs(distinctNetworkIds.toSet)
+    )
+  }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -707,7 +707,9 @@ object TransactionSyntaxInterpreter {
   /**
    * Validate that all the lock addresses in the transaction share the same network ID
    */
-  private def lockAddressesNetworkIdValidation(transaction: IoTransaction): ValidatedNec[TransactionSyntaxError, Unit] = {
+  private def lockAddressesNetworkIdValidation(
+    transaction: IoTransaction
+  ): ValidatedNec[TransactionSyntaxError, Unit] = {
     val networkIds = transaction.inputs.map(_.address.network) ++ transaction.outputs.map(_.address.network)
     val distinctNetworkIds = networkIds.distinct
     Validated.condNec(

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -20,8 +20,8 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
   /**
    * Reasons:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -21,8 +21,8 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a Group constructor Token") {
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
@@ -21,8 +21,8 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a Series constructor Token") {
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -19,10 +19,10 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
-  private val txoAddress_3 = TransactionOutputAddress(3, 0, 0, dummyTxIdentifier)
-  private val txoAddress_4 = TransactionOutputAddress(4, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
+  private val txoAddress_3 = TransactionOutputAddress(0, 0, 3, dummyTxIdentifier)
+  private val txoAddress_4 = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a Asset Token Unlimited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
@@ -805,10 +805,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
    */
   test("Invalid data-input case 4, minting a Asset Token Limited") {
 
-    val utxo_xyz = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-    val utxo_abc = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
-    val utxo_def = TransactionOutputAddress(3, 0, 0, dummyTxIdentifier)
-    val utxo_uvw = TransactionOutputAddress(4, 0, 0, dummyTxIdentifier)
+    val utxo_xyz = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+    val utxo_abc = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
+    val utxo_def = TransactionOutputAddress(0, 0, 3, dummyTxIdentifier)
+    val utxo_uvw = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
     val dummyTxoAddress = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
 
@@ -909,10 +909,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
    */
   test("Valid data-input case 5, minting 2 Asset Token Limited, with 2 groups and 2 series") {
     val utxo = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
-    val utxo1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-    val utxo2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
-    val utxo3 = TransactionOutputAddress(3, 0, 0, dummyTxIdentifier)
-    val utxo4 = TransactionOutputAddress(4, 0, 0, dummyTxIdentifier)
+    val utxo1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+    val utxo2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
+    val utxo3 = TransactionOutputAddress(0, 0, 3, dummyTxIdentifier)
+    val utxo4 = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
     val gA = Event.GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
     val gB = Event.GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
@@ -1009,10 +1009,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
    */
   test("Invalid data-input case 6, minting 2 Asset Token Limited, with 2 groups and 2 series") {
     val utxo = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
-    val utxo1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-    val utxo2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
-    val utxo3 = TransactionOutputAddress(3, 0, 0, dummyTxIdentifier)
-    val utxo4 = TransactionOutputAddress(4, 0, 0, dummyTxIdentifier)
+    val utxo1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+    val utxo2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
+    val utxo3 = TransactionOutputAddress(0, 0, 3, dummyTxIdentifier)
+    val utxo4 = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
     val gA = Event.GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
     val gB = Event.GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
@@ -1097,8 +1097,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
    */
   test("Invalid data-input case 7, minting 1 Asset, series Utxo does not refer to a series token") {
     val utxo = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
-    val utxo_abc = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-    val utxo_xyz = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+    val utxo_abc = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+    val utxo_xyz = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
     val g1 = Event.GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
 
@@ -1159,8 +1159,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
    */
   test("Invalid data-input case 8, minting 1 Asset, group Utxo does not refer to a series token") {
     val utxo = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
-    val utxo_abc = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-    val utxo_xyz = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+    val utxo_abc = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+    val utxo_xyz = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
     val g1 = Event.GroupPolicy(label = "g1", registrationUtxo = utxo_xyz)
     val s1 = Event.SeriesPolicy(label = "s1", registrationUtxo = utxo, tokenSupply = Some(5))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec.scala
@@ -16,7 +16,7 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a proposal updated Token") {
     val value_1_in: Value =

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -19,8 +19,8 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
   /**
    * In this case there 2 validations that are failing;

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
@@ -174,6 +174,11 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
-    assertEquals(result.exists(_.toList.contains(TransactionSyntaxError.InconsistentNetworkIDs(Set(MAIN_NETWORK_ID, TEST_NETWORK_ID)))), true)
+    assertEquals(
+      result.exists(
+        _.toList.contains(TransactionSyntaxError.InconsistentNetworkIDs(Set(MAIN_NETWORK_ID, TEST_NETWORK_ID)))
+      ),
+      true
+    )
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
@@ -3,17 +3,12 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.Attestation
-import co.topl.brambl.models.box.Challenge
-import co.topl.brambl.models.box.Lock
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.constants.NetworkConstants.{MAIN_NETWORK_ID, TEST_NETWORK_ID}
+import co.topl.brambl.models.box.{Attestation, Challenge, Lock, Value}
 import co.topl.brambl.models.transaction.Schedule
-import co.topl.quivr.api.Proposer
-import co.topl.quivr.api.Prover
+import co.topl.quivr.api.{Proposer, Prover}
 import com.google.protobuf.ByteString
-import quivr.models.Int128
-import quivr.models.Proof
-import quivr.models.Proposition
+import quivr.models.{Int128, Proof, Proposition}
 
 class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
 
@@ -168,5 +163,17 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
       .swap
       .exists(_.toList.contains(TransactionSyntaxError.InvalidDataLength))
     assertEquals(result, true)
+  }
+
+  test("Mismatched Network IDs ") {
+    val inputs = txFull.inputs.map(in => in.copy(address = in.address.withNetwork(MAIN_NETWORK_ID)))
+    val outputs = txFull.outputs.map(out => out.copy(address = out.address.withNetwork(MAIN_NETWORK_ID)))
+    val testTx = txFull.copy(
+      outputs = outputs :+ outputs.head.copy(address = outputs.head.address.withNetwork(TEST_NETWORK_ID)),
+      inputs = inputs.head.copy(address = inputs.head.address.withNetwork(TEST_NETWORK_ID)) +: inputs
+    )
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+    assertEquals(result.exists(_.toList.contains(TransactionSyntaxError.InconsistentNetworkIDs(Set(MAIN_NETWORK_ID, TEST_NETWORK_ID)))), true)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
@@ -16,7 +16,7 @@ import co.topl.brambl.syntax._
  */
 class TransactionSyntaxInterpreterTransferSeriesSpec extends munit.FunSuite with MockHelpers {
 
-  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
+  private val txoAddress_1 = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
   TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
 
   test("Valid data-input case, transfer a simple series ") {


### PR DESCRIPTION
## Purpose

There have been cases of the wrong address type being used. For ex: “ptet” addresses used instead of “vtet” for test network. 

## Approach

Add syntax validation for all addresses in a transaction being only one of “ptet” “vtet” etc.. i.e, dont mix network ids for any lock addresses in inputs and outputs

## Testing

- Added unit test 
- updated existing tests to pass

## Tickets
* Closes TSDK-763