### PR TITLE
TSDK-888 Transfer Funds using the Easy API

### DIFF
--- a/documentation/docs/reference/easy-api.md
+++ b/documentation/docs/reference/easy-api.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Easy Api
+title: Easy API
 ---
 
 For the most common use cases, we provide an easy-to-use API that allows you to interact with the platform without having 
@@ -33,23 +33,82 @@ def initialize[F[_]: Async](
 Optionally, you can provide a custom configuration to the `initialize` method. The configuration allows you to specify the
 network to use, the node to connect to, and wallet storage files. If you don't provide a configuration, the default one will be used.
 
-### Example
+## Usage
+
+The Easy API makes it easy to transfer funds from one wallet account to another. Certain methods are provided to help you do so:
+
+- `transferFunds`: Transfer funds from one account to another.
+- `getBalance`: Get the balance of an account.
+- `getAddressToReceiveFunds`: Generate an address to receive funds into an account.
+
+By default, you have two accounts loaded into your wallet during initialization: the default account (`DefaultAccount`) and the faucet account (`GenesisAccount`). 
+
+### Transfer Funds
+
+To transfer funds from one account to another, you need to provide the sender account, the recipient address, the amount to transfer, the value type, and the fee. 
+The sender account must have enough funds to cover the amount to transfer and the fee and must exist in your local wallet.
+Any excess funds (i.e. change) will be transferred back into the sender account.
+
+```scala
+def transferFunds(
+    from:      WalletAccount,
+    recipient: LockAddress,
+    amount:    Long,
+    valueType: ValueTypeIdentifier,
+    fee:       Long
+): F[TransactionId]
+```
+
+### Get Balance
+
+You can get the balance of an account using the following method. The resulting balance is grouped by value type.
+
+```scala
+def getBalance(account: WalletAccount): F[Map[ValueTypeIdentifier, Long]]
+```
+
+### Get Address to Receive Funds
+
+To receive funds into an account, you need to first generate an address. This address can be used to receive funds from other accounts or other users.
+
+```scala
+def getAddressToReceiveFunds(account: WalletAccount): F[LockAddress]
+```
+
+## Example
+
+The following example demonstrates how to initialize the Easy API and load your default wallet account (`DefaultAccount`) 
+with 100Lvls from the faucet account (`GenesisAccount`). Finally, it prints the new balance of the default account.
+
+For the code to work, you need to have a local instance of the node running.
 
 ```scala
 package xyz.stratalab.strata.servicekit
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import xyz.stratalab.sdk.constants.NetworkConstants.PRIVATE_NETWORK_ID
+import xyz.stratalab.sdk.syntax.LvlType
+import xyz.stratalab.strata.servicekit.EasyApi.{DefaultAccount, GenesisAccount, InitArgs}
 
-class Demo {
-  val initialization = for {
-    api <- EasyApi.initialize[IO]("your-wallet-password")
-    /*
-    * You can now the the api object to interact with the SDK here
-    */
-  } yield api
+import scala.concurrent.duration.DurationInt
+
+object Demo extends App {
+  val Api = for {
+    api <- EasyApi.initialize[IO]("your-wallet-password", InitArgs(networkId = PRIVATE_NETWORK_ID, keyFile = "default.db"))
+    receivingAddress <- api.getAddressToReceiveFunds(DefaultAccount)
+    _ <- api.transferFunds(GenesisAccount, receivingAddress, 100L, LvlType, 1L).andWait(15.seconds)
+    walletBalance <- api.getBalance(DefaultAccount)
+    _ <- IO.println(s"Wallet balance: \n$walletBalance")
+  } yield ()
+
+  Api.unsafeRunSync()
 }
 ```
 
-## Usage
+After running, you should be able to see that your default account has been loaded with 100Lvls.
 
-TBD
+```bash
+Wallet balance: 
+Map(LvlType -> 100)
+```

--- a/service-kit/src/main/scala/xyz/stratalab/strata/servicekit/EasyApi.scala
+++ b/service-kit/src/main/scala/xyz/stratalab/strata/servicekit/EasyApi.scala
@@ -34,32 +34,95 @@ class EasyApi[F[
   val genusQueryAlgebra: GenusQueryAlgebra[F] = implicitly[GenusQueryAlgebra[F]]
   val credentialler: Credentialler[F] = implicitly[Credentialler[F]]
 
-  def transferFunds(from: WalletAccount, recipient: LockAddress, amount: Long, valueType: ValueTypeIdentifier, fee: Long): F[TransactionId] = {
+  def transferFunds(
+    from:      WalletAccount,
+    recipient: LockAddress,
+    amount:    Long,
+    valueType: ValueTypeIdentifier,
+    fee:       Long
+  ): F[TransactionId] =
     (for {
-      curIdx <- EitherT(walletStateAlgebra.getCurrentIndicesForFunds(from.fellowship, from.template, None).map(_.toRight(new RuntimeException("Invalid (fellowship, template) pair"))))
-      inputLock <- EitherT(walletStateAlgebra.getLock(from.fellowship, from.template, curIdx.z).map(_.toRight(new RuntimeException("Unable to get lock for (fellowship, template) pair"))))
+      curIdx <- EitherT(
+        walletStateAlgebra
+          .getCurrentIndicesForFunds(from.fellowship, from.template, None)
+          .map(_.toRight(new RuntimeException("Invalid (fellowship, template) pair")))
+      )
+      inputLock <- EitherT(
+        walletStateAlgebra
+          .getLock(from.fellowship, from.template, curIdx.z)
+          .map(_.toRight(new RuntimeException("Unable to get lock for (fellowship, template) pair")))
+      )
       inputAddr <- EitherT(transactionBuilderApi.lockAddress(inputLock).map(_.asRight[RuntimeException]))
-      txos <- EitherT(genusQueryAlgebra.queryUtxo(inputAddr).map(_.asRight[RuntimeException]).handleError(e => new RuntimeException("Unable to query UTXO", e).asLeft))
-      changeLock <- EitherT(walletStateAlgebra.getLock(from.fellowship, from.template, curIdx.z + 1).map(_.toRight(new RuntimeException("Unable to get change lock for next (fellowship, template) pair"))))
+      txos <- EitherT(
+        genusQueryAlgebra
+          .queryUtxo(inputAddr)
+          .map(_.asRight[RuntimeException])
+          .handleError(e => new RuntimeException("Unable to query UTXO", e).asLeft)
+      )
+      changeLock <- EitherT(
+        walletStateAlgebra
+          .getLock(from.fellowship, from.template, curIdx.z + 1)
+          .map(_.toRight(new RuntimeException("Unable to get change lock for next (fellowship, template) pair")))
+      )
       changeAddr <- EitherT(transactionBuilderApi.lockAddress(changeLock).map(_.asRight[RuntimeException]))
-      unproven <- EitherT(transactionBuilderApi
-        .buildTransferAmountTransaction(valueType, txos, inputLock.getPredicate, amount, recipient, changeAddr, fee)
-        .map(_.leftMap(err => new RuntimeException("Unable to build transaction", err))))
-      context <- EitherT(buildContext(unproven).map(_.asRight[RuntimeException]).handleError(e => new RuntimeException("Unable to build context", e).asLeft))
-      proven <- EitherT(credentialler.proveAndValidate(unproven, context).map(_.leftMap(errs => new RuntimeException("Transaction failed validation", InvalidTransaction(errs)))))
-      txId    <- EitherT(bifrostQueryAlgebra.broadcastTransaction(proven).map(_.asRight[RuntimeException]).handleError(e => new RuntimeException("Broadcast transaction failed", e).asLeft))
+      unproven <- EitherT(
+        transactionBuilderApi
+          .buildTransferAmountTransaction(valueType, txos, inputLock.getPredicate, amount, recipient, changeAddr, fee)
+          .map(_.leftMap(err => new RuntimeException("Unable to build transaction", err)))
+      )
+      context <- EitherT(
+        buildContext(unproven)
+          .map(_.asRight[RuntimeException])
+          .handleError(e => new RuntimeException("Unable to build context", e).asLeft)
+      )
+      proven <- EitherT(
+        credentialler
+          .proveAndValidate(unproven, context)
+          .map(_.leftMap(errs => new RuntimeException("Transaction failed validation", InvalidTransaction(errs))))
+      )
+      txId <- EitherT(
+        bifrostQueryAlgebra
+          .broadcastTransaction(proven)
+          .map(_.asRight[RuntimeException])
+          .handleError(e => new RuntimeException("Broadcast transaction failed", e).asLeft)
+      )
       hasChange = proven.outputs.map(_.address).contains(changeAddr) // check if change address is in outputs
-      res <- if(hasChange) for {
-        // The vk in the cartesian wallet state will always refer to the derivation of the user's main key (which can partially be obtained via the Default account)
-        parentVk <- EitherT(walletStateAlgebra.getEntityVks(DefaultAccount.fellowship, DefaultAccount.template).map(_.flatMap(_.headOption.flatMap(vk => Encoding.decodeFromBase58(vk).toOption)).toRight(new RuntimeException("Unable to get (self,default) VK")).map(VerificationKey.parseFrom)))
-        childVk <- EitherT(walletApi.deriveChildVerificationKey(parentVk, curIdx.z + 1).map(_.asRight[RuntimeException]).handleError(e => new RuntimeException("Unable to derive child verification key", e).asLeft))
-        res <- EitherT(walletStateAlgebra.updateWalletState(Encoding.encodeToBase58(changeLock.getPredicate.toByteArray), changeAddr.toBase58(), Some("ExtendedEd25519"), Some(Encoding.encodeToBase58(childVk.toByteArray)), curIdx.copy(z = curIdx.z+1)).map(_ => txId.asRight[RuntimeException]).handleError(e => new RuntimeException("Unable to update wallet state", e).asLeft))
-      } yield res else EitherT.pure[F, RuntimeException](txId)
+      res <-
+        if (hasChange) for {
+          // The vk in the cartesian wallet state will always refer to the derivation of the user's main key (which can partially be obtained via the Default account)
+          parentVk <- EitherT(
+            walletStateAlgebra
+              .getEntityVks(DefaultAccount.fellowship, DefaultAccount.template)
+              .map(
+                _.flatMap(_.headOption.flatMap(vk => Encoding.decodeFromBase58(vk).toOption))
+                  .toRight(new RuntimeException("Unable to get (self,default) VK"))
+                  .map(VerificationKey.parseFrom)
+              )
+          )
+          childVk <- EitherT(
+            walletApi
+              .deriveChildVerificationKey(parentVk, curIdx.z + 1)
+              .map(_.asRight[RuntimeException])
+              .handleError(e => new RuntimeException("Unable to derive child verification key", e).asLeft)
+          )
+          res <- EitherT(
+            walletStateAlgebra
+              .updateWalletState(
+                Encoding.encodeToBase58(changeLock.getPredicate.toByteArray),
+                changeAddr.toBase58(),
+                Some("ExtendedEd25519"),
+                Some(Encoding.encodeToBase58(childVk.toByteArray)),
+                curIdx.copy(z = curIdx.z + 1)
+              )
+              .map(_ => txId.asRight[RuntimeException])
+              .handleError(e => new RuntimeException("Unable to update wallet state", e).asLeft)
+          )
+        } yield res
+        else EitherT.pure[F, RuntimeException](txId)
     } yield res).value map {
-      case Left(err) => throw UnableToTransferFunds(err)
+      case Left(err)   => throw UnableToTransferFunds(err)
       case Right(txId) => txId
     }
-  }
 
   def buildContext(tx: IoTransaction): F[Context[F]] = for {
     tipBlockHeader <- bifrostQueryAlgebra
@@ -101,7 +164,6 @@ object EasyApi {
   // Common (fellowship, template) pairs
   val DefaultAccount: WalletAccount = WalletAccount("self", "default")
   val GenesisAccount: WalletAccount = WalletAccount("nofellowship", "genesis")
-
 
   def initialize[F[_]: Async](
     password: String,

--- a/service-kit/src/main/scala/xyz/stratalab/strata/servicekit/EasyApi.scala
+++ b/service-kit/src/main/scala/xyz/stratalab/strata/servicekit/EasyApi.scala
@@ -17,7 +17,12 @@ import xyz.stratalab.sdk.syntax.ValueTypeIdentifier
 import xyz.stratalab.sdk.utils.Encoding
 import xyz.stratalab.sdk.wallet.CredentiallerInterpreter.InvalidTransaction
 import xyz.stratalab.sdk.wallet.{Credentialler, CredentiallerInterpreter, WalletApi}
-import xyz.stratalab.strata.servicekit.EasyApi.{DefaultAccount, UnableToGetBalance, UnableToTransferFunds, WalletAccount}
+import xyz.stratalab.strata.servicekit.EasyApi.{
+  DefaultAccount,
+  UnableToGetBalance,
+  UnableToTransferFunds,
+  WalletAccount
+}
 import xyz.stratalab.sdk.syntax.{int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 
 import java.nio.charset.StandardCharsets
@@ -138,10 +143,19 @@ class EasyApi[F[
       )
     ).lift
   )
-  def getBalance(account: WalletAccount): F[Map[ValueTypeIdentifier, Long]] = {
+
+  def getBalance(account: WalletAccount): F[Map[ValueTypeIdentifier, Long]] =
     (for {
-      curIdx <- EitherT(walletStateAlgebra.getCurrentIndicesForFunds(account.fellowship, account.template, None).map(_.toRight(new RuntimeException("Invalid (fellowship, template) pair"))))
-      lock <- EitherT(walletStateAlgebra.getLock(account.fellowship, account.template, curIdx.z).map(_.toRight(new RuntimeException("Unable to get lock for (fellowship, template) pair"))))
+      curIdx <- EitherT(
+        walletStateAlgebra
+          .getCurrentIndicesForFunds(account.fellowship, account.template, None)
+          .map(_.toRight(new RuntimeException("Invalid (fellowship, template) pair")))
+      )
+      lock <- EitherT(
+        walletStateAlgebra
+          .getLock(account.fellowship, account.template, curIdx.z)
+          .map(_.toRight(new RuntimeException("Unable to get lock for (fellowship, template) pair")))
+      )
       lockAddr <- EitherT(transactionBuilderApi.lockAddress(lock).map(_.asRight[RuntimeException]))
       utxos <- EitherT(
         genusQueryAlgebra
@@ -149,11 +163,14 @@ class EasyApi[F[
           .map(_.asRight[RuntimeException])
           .handleError(e => new RuntimeException("Unable to query UTXO", e).asLeft)
       )
-    } yield utxos.map(_.transactionOutput.value.value).groupBy(_.typeIdentifier).view.mapValues(_.map(_.quantity: BigInt).sum.toLong)).value map {
-      case Left(err) => throw UnableToGetBalance(err)
+    } yield utxos
+      .map(_.transactionOutput.value.value)
+      .groupBy(_.typeIdentifier)
+      .view
+      .mapValues(_.map(_.quantity: BigInt).sum.toLong)).value map {
+      case Left(err)  => throw UnableToGetBalance(err)
       case Right(res) => res.toMap
     }
-  }
 }
 
 object EasyApi {

--- a/service-kit/src/test/scala/xyz/stratalab/sdk/servicekit/EasyApiSpec.scala
+++ b/service-kit/src/test/scala/xyz/stratalab/sdk/servicekit/EasyApiSpec.scala
@@ -130,7 +130,7 @@ class EasyApiSpec extends CatsEffectSuite with BaseSpec {
     implicit val walletApi: WalletApi[IO] = original.walletApi
     implicit val transactionBuilderApi: TransactionBuilderApi[IO] = original.transactionBuilderApi
     implicit val credentialler: Credentialler[IO] = original.credentialler
-    implicit val genusQueryAlgebra: GenusQueryAlgebra[IO] = (fromAddress: LockAddress, txoState: TxoState) =>
+    implicit val genusQueryAlgebra: GenusQueryAlgebra[IO] = (_: LockAddress, _: TxoState) =>
       IO.pure(
         Seq(
           Txo(

--- a/service-kit/src/test/scala/xyz/stratalab/sdk/servicekit/EasyApiSpec.scala
+++ b/service-kit/src/test/scala/xyz/stratalab/sdk/servicekit/EasyApiSpec.scala
@@ -1,18 +1,26 @@
 package xyz.stratalab.sdk.servicekit
 
+import cats.Id
 import cats.effect.IO
-import co.topl.brambl.models.{Indices, LockAddress, TransactionId}
-import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.consensus.models.{BlockHeader, BlockId}
+import co.topl.brambl.models._
+import co.topl.brambl.models.box.{Challenge, Lock, Value}
+import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
+import co.topl.consensus.models._
 import co.topl.genus.services.{Txo, TxoState}
 import co.topl.node.models.BlockBody
 import co.topl.node.services.SynchronizationTraversalRes
+import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
+import xyz.stratalab.quivr.api.Proposer
 import xyz.stratalab.sdk.builders.TransactionBuilderApi
-import xyz.stratalab.sdk.dataApi.{BifrostQueryAlgebra, FellowshipStorageAlgebra, GenusQueryAlgebra, TemplateStorageAlgebra, WalletKeyApiAlgebra, WalletStateAlgebra}
+import xyz.stratalab.sdk.common.ContainsEvidence.Ops
+import xyz.stratalab.sdk.common.ContainsImmutable.instances.lockImmutable
+import xyz.stratalab.sdk.constants.NetworkConstants.{MAIN_LEDGER_ID, MAIN_NETWORK_ID}
+import xyz.stratalab.sdk.dataApi._
+import xyz.stratalab.sdk.syntax.{LvlType, bigIntAsInt128}
 import xyz.stratalab.sdk.wallet.{Credentialler, WalletApi}
 import xyz.stratalab.strata.servicekit.EasyApi
-import xyz.stratalab.strata.servicekit.EasyApi.{InitArgs, UnableToInitializeSdk}
+import xyz.stratalab.strata.servicekit.EasyApi._
 
 class EasyApiSpec extends CatsEffectSuite with BaseSpec {
 
@@ -96,6 +104,8 @@ class EasyApiSpec extends CatsEffectSuite with BaseSpec {
       } yield true
     )
   }
+
+  private val HeightLockAddr = LockAddress(network = MAIN_NETWORK_ID, ledger = MAIN_LEDGER_ID, id = LockId(Lock().withPredicate(Lock.Predicate(List(Challenge().withRevealed(Proposer.heightProposer[Id].propose("header", 1, Long.MaxValue))), 1)).sizedEvidence.digest.value))
   private def mockEasyApi(original: EasyApi[IO]): EasyApi[IO] = {
     implicit val walletKeyApiAlgebra: WalletKeyApiAlgebra[IO] = original.walletKeyApiAlgebra
     implicit val walletStateAlgebra: WalletStateAlgebra[IO] = original.walletStateAlgebra
@@ -104,34 +114,131 @@ class EasyApiSpec extends CatsEffectSuite with BaseSpec {
     implicit val walletApi: WalletApi[IO] = original.walletApi
     implicit val transactionBuilderApi: TransactionBuilderApi[IO] = original.transactionBuilderApi
     implicit val credentialler: Credentialler[IO] = original.credentialler
+    implicit val genusQueryAlgebra: GenusQueryAlgebra[IO] = (fromAddress: LockAddress, txoState: TxoState) => IO.pure(Seq(
+      Txo(
+        transactionOutput = UnspentTransactionOutput(HeightLockAddr, Value.defaultInstance.withLvl(Value.LVL(BigInt(500)))),
+        outputAddress = TransactionOutputAddress(network = MAIN_NETWORK_ID, ledger = MAIN_LEDGER_ID, id = TransactionId(ByteString.copyFrom(Array.fill(32)(0.toByte))))
+      )
+    ))
     implicit val bifrostQueryAlgebra: BifrostQueryAlgebra[IO] = new BifrostQueryAlgebra[IO] {
-      override def blockByHeight(height: Long) = ???
+      override def blockByDepth(depth: Long): IO[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = IO.pure(
+        Some(
+          (
+            BlockId(ByteString.copyFrom(Array.fill(32)(0.toByte))),
+            BlockHeader(parentHeaderId = BlockId(ByteString.copyFrom(Array.fill(32)(0.toByte))),
+              txRoot = ByteString.copyFrom(Array.fill(32)(0.toByte)), bloomFilter = ByteString.copyFrom(Array.fill(256)(0.toByte)),
+              height = 50,
+              slot = 100,
+              eligibilityCertificate = EligibilityCertificate(ByteString.copyFrom(Array.fill(80)(0.toByte)), ByteString.copyFrom(Array.fill(32)(0.toByte)), ByteString.copyFrom(Array.fill(32)(0.toByte)), ByteString.copyFrom(Array.fill(32)(0.toByte))),
+              operationalCertificate = OperationalCertificate(
+                VerificationKeyKesProduct(ByteString.copyFrom(Array.fill(32)(0.toByte))),
+                SignatureKesProduct(
+                  SignatureKesSum(ByteString.copyFrom(Array.fill(32)(0.toByte)), ByteString.copyFrom(Array.fill(64)(0.toByte))),
+                  SignatureKesSum(ByteString.copyFrom(Array.fill(32)(0.toByte)), ByteString.copyFrom(Array.fill(64)(0.toByte))),
+                  ByteString.copyFrom(Array.fill(32)(0.toByte))
+                ),
+                ByteString.copyFrom(Array.fill(32)(0.toByte)),
+                ByteString.copyFrom(Array.fill(64)(0.toByte))
+              ),
+              address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0.toByte))),
+              version = ProtocolVersion.defaultInstance
+            ),
+            BlockBody(Seq.empty, None),
+            Seq.empty
+          )
+        )
+      )
+      override def broadcastTransaction(tx: IoTransaction): IO[TransactionId] = IO.pure(TransactionId(ByteString.copyFrom(Array.fill(32)(0.toByte))))
 
-      override def blockByDepth(depth: Long) = ???
-
+      override def blockByHeight(height: Long): IO[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = ???
       override def blockById(blockId: BlockId): IO[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = ???
-
       override def fetchTransaction(txId: TransactionId): IO[Option[IoTransaction]] = ???
-
-      override def broadcastTransaction(tx: IoTransaction): IO[TransactionId] = ???
-
       override def synchronizationTraversal(): IO[Iterator[SynchronizationTraversalRes]] = ???
-
       override def makeBlock(nbOfBlocks: Int): IO[Unit] = ???
-    }
-    implicit val genusQueryAlgebra: GenusQueryAlgebra[IO] = new GenusQueryAlgebra[IO] {
-      override def queryUtxo(fromAddress: LockAddress, txoState: TxoState): IO[Seq[Txo]] = ???
     }
     new EasyApi[IO]
   }
 
-  testDirectory.test("Get Balance > Simple") { _ =>
+  testDirectory.test("Get Balance > Happy Path") { _ =>
     assertIO(
       obtained = for {
         initialize <- EasyApi.initialize[IO]("password", testArgs)
         mockApi = mockEasyApi(initialize)
-      } yield 1,
-      returns = 1
+        balance <- mockApi.getBalance(GenesisAccount)
+      } yield balance == Map(LvlType -> 500),
+      true
     )
+  }
+
+  testDirectory.test("Get Balance > An exception occurred") { _ =>
+    interceptIO[UnableToGetBalance](for {
+      initialize <- EasyApi.initialize[IO]("password", testArgs)
+      mockApi = mockEasyApi(initialize)
+      balance <- mockApi.getBalance(WalletAccount("does-not", "exist"))
+    } yield true)
+  }
+
+  testDirectory.test("Build Context > Happy Path") { _ =>
+    assertIO(
+      obtained = for {
+        initialize <- EasyApi.initialize[IO]("password", testArgs)
+        mockApi = mockEasyApi(initialize)
+        ctx <- mockApi.buildContext(IoTransaction.defaultInstance)
+      } yield ctx.curTick == 100 && ctx.datums("header").flatMap(_.value.header.map(_.event.height)).contains(50),
+      true
+    )
+  }
+
+  testDirectory.test("Get Address > Happy Path") { _ =>
+    assertIO(
+      obtained = for {
+        initialize <- EasyApi.initialize[IO]("password", testArgs)
+        mockApi = mockEasyApi(initialize)
+        addr <- mockApi.getAddressToReceiveFunds(GenesisAccount)
+      } yield addr == HeightLockAddr,
+      true
+    )
+  }
+  testDirectory.test("Get Address > An exception occurred") { _ =>
+    interceptIO[UnableToGetAddressForFunds](for {
+      initialize <- EasyApi.initialize[IO]("password", testArgs)
+      mockApi = mockEasyApi(initialize)
+      addr <- mockApi.getAddressToReceiveFunds(WalletAccount("does-not", "exist"))
+    } yield true)
+  }
+  testDirectory.test("Transfer 100Lvls > Happy Path") { _ =>
+    assertIO(
+      obtained = for {
+        initialize <- EasyApi.initialize[IO]("password", testArgs)
+        mockApi = mockEasyApi(initialize)
+        addr <- mockApi.getAddressToReceiveFunds(DefaultAccount)
+        txId <- mockApi.transferFunds(GenesisAccount, addr, 100L, LvlType, 1L)
+      } yield txId == TransactionId(ByteString.copyFrom(Array.fill(32)(0.toByte))),
+      true
+    )
+  }
+  testDirectory.test("Transfer 100Lvls > Invalid From Account") { _ =>
+    interceptMessageIO[UnableToTransferFunds]("Issue transferring funds: Unable to get lock for (does-not, exist) account")(for {
+      initialize <- EasyApi.initialize[IO]("password", testArgs)
+      mockApi = mockEasyApi(initialize)
+      addr <- mockApi.getAddressToReceiveFunds(DefaultAccount)
+      txId <- mockApi.transferFunds(WalletAccount("does-not", "exist"), addr, 100L, LvlType, 1L)
+    } yield true)
+  }
+  testDirectory.test("Transfer 700Lvls > Not enough funds") { _ =>
+    interceptMessageIO[UnableToTransferFunds]("Issue transferring funds: Unable to build transaction")(for {
+      initialize <- EasyApi.initialize[IO]("password", testArgs)
+      mockApi = mockEasyApi(initialize)
+      addr <- mockApi.getAddressToReceiveFunds(DefaultAccount)
+      txId <- mockApi.transferFunds(GenesisAccount, addr, 700L, LvlType, 1L)
+    } yield true)
+  }
+  testDirectory.test("Transfer 100Lvls > Invalid Transaction") { _ =>
+    interceptMessageIO[UnableToTransferFunds]("Issue transferring funds: Transaction failed validation")(for {
+      initialize <- EasyApi.initialize[IO]("password", testArgs)
+      mockApi = mockEasyApi(initialize)
+      addr <- mockApi.getAddressToReceiveFunds(DefaultAccount)
+      txId <- mockApi.transferFunds(GenesisAccount, addr.withNetwork(0), 100L, LvlType, 1L)
+    } yield true)
   }
 }

--- a/strata-sdk/src/main/scala/xyz/stratalab/strata/wallet/CredentiallerInterpreter.scala
+++ b/strata-sdk/src/main/scala/xyz/stratalab/strata/wallet/CredentiallerInterpreter.scala
@@ -324,4 +324,5 @@ object CredentiallerInterpreter {
         .flatMap(proofs => Prover.thresholdProver[F].prove(proofs.toSet, msg))
     }
   }
+  case class InvalidTransaction(errs: List[ValidationError]) extends RuntimeException
 }


### PR DESCRIPTION
## Purpose

Provide an easy way for users to transfer funds using the SDK.

## Approach

Added a few new functions to the Easy API.

- getAddressToReceiveFunds (generate a recipient lock address)
- transferFunds (one-liner to perform the transfer)
- getBalance (view balance)

The docusaurus documentation was also updated

## Testing

- Added unit tests
- Manually ensured that transferring funds works as expected (see below)

Ran the node locally:

```
docker run -d --name bifrost -p 9084:9084 docker.io/toplprotocol/bifrost-node:2.0.0-beta3
```

Ran the following code:
```
package xyz.stratalab.strata.servicekit

import cats.effect.IO
import cats.effect.unsafe.implicits.global
import xyz.stratalab.sdk.constants.NetworkConstants.PRIVATE_NETWORK_ID
import xyz.stratalab.sdk.syntax.LvlType
import xyz.stratalab.strata.servicekit.EasyApi.{DefaultAccount, GenesisAccount, InitArgs}

import scala.concurrent.duration.DurationInt

object Demo extends App {
  val Api = for {
    api <- EasyApi.initialize[IO]("your-wallet-password", InitArgs(networkId = PRIVATE_NETWORK_ID, keyFile = "default.db"))
    receivingAddress <- api.getAddressToReceiveFunds(DefaultAccount)
    _ <- api.transferFunds(GenesisAccount, receivingAddress, 100L, LvlType, 1L).andWait(15.seconds)
    walletBalance <- api.getBalance(DefaultAccount)
    _ <- IO.println(s"Wallet balance: \n$walletBalance")
  } yield ()

  Api.unsafeRunSync()
}
```

Received the following output:
```
Wallet balance: 
Map(LvlType -> 100)
```

## Tickets
* closes TSDK-888